### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 [![Build Status](https://travis-ci.org/laco/python-centaur.svg?branch=master)](https://travis-ci.org/laco/python-centaur)
 [![Coverage Status](https://coveralls.io/repos/github/laco/python-centaur/badge.svg?branch=master)](https://coveralls.io/github/laco/python-centaur?branch=master)
 [![Requirements Status](https://requires.io/github/laco/python-centaur/requirements.svg?branch=master)](https://requires.io/github/laco/python-centaur/requirements/?branch=master)
-[![PyPi version](https://pypip.in/v/Centaur/badge.png)](https://crate.io/packages/Centaur/)
+[![PyPi version](https://img.shields.io/pypi/v/Centaur.svg)](https://crate.io/packages/Centaur/)
 
 General Purpose Python3 Application Framework (Port-Adapter Architecture)


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20centaur))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `centaur`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.